### PR TITLE
bodyPart highlights

### DIFF
--- a/src/elm/Data/Stim.elm
+++ b/src/elm/Data/Stim.elm
@@ -10,7 +10,7 @@ import Types exposing (..)
 
 defaultStim : Stim
 defaultStim =
-    Stim "" Chest "" "" Nothing False ""
+    Stim "" NoBodyPart "" "" Nothing False ""
 
 
 decodeStim : Decoder Stim

--- a/src/elm/State.elm
+++ b/src/elm/State.elm
@@ -178,3 +178,8 @@ update msg model =
 
         AddAvatarName name ->
             { model | avatarName = name } ! []
+
+        AddStimWithoutBodyPart ->
+            { model | newStim = defaultStim }
+                ! []
+                :> update (NavigateTo AddStim)

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -259,3 +259,4 @@ type Msg
     | AddHowTo String
     | SelectAvatar
     | AddAvatarName String
+    | AddStimWithoutBodyPart

--- a/src/elm/Views/Landing.elm
+++ b/src/elm/Views/Landing.elm
@@ -38,7 +38,7 @@ landing model =
         , button
             [ classes [ "bn", "bg-transparent", "db", "h4", "w4", "fixed", "bottom-0", "outline-0", "z-2" ]
             , backgroundImageStyle "./assets/Landing/add_stim_btn.svg" 100
-            , onClick <| NavigateTo AddStim
+            , onClick <| AddStimWithoutBodyPart
             ]
             []
         ]


### PR DESCRIPTION
- changes defaultStim.bodyPart to NoBodyPart
- clears newStim bodypart if go from big blue button so none of the bodyparts are highlighted on loading addStim view